### PR TITLE
Do not explicitly create the CouchPotato data directory

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,24 +27,6 @@
     owner: "{{ couchpotato_daemon_user }}"
     mode: '0755'
 
-- name: 'Create the couchpotato data directory'
-  file:
-    path: "{{ couchpotato_app_data_directory }}"
-    state: 'directory'
-    owner: "{{ couchpotato_daemon_user }}"
-    mode: '0755'
-
-- name: 'Create the couchpotato data directories'
-  file:
-    path: "{{ couchpotato_app_data_directory }}/{{ item }}"
-    state: 'directory'
-    owner: "{{ couchpotato_daemon_user }}"
-    mode: '0755'
-  with_items:
-    - 'config'
-    - 'downloads'
-    - 'incomplete-downloads'
-
 - name: 'Git clone couchpotato to the src directory'
   git:
     clone: 'yes'

--- a/templates/couchpotato.j2
+++ b/templates/couchpotato.j2
@@ -1,5 +1,5 @@
 CP_USER={{ couchpotato_daemon_user }}
 CP_HOME={{ couchpotato_app_src_directory }}
-CP_DATA={{ couchpotato_app_data_directory }}/config
+CP_DATA={{ couchpotato_app_data_directory }}
 CP_PIDFILE={{ couchpotato_app_pid_file }}
 CP_OPTS="{{ couchpotato_daemon_extra_args }}"


### PR DESCRIPTION
This can be easily handled via the init script which has the side-effect of allowing callers to (easily) specify the location of the data directory without both caller-callee ansible modules stepping all over each other.
